### PR TITLE
Fix upload artifact deprecation

### DIFF
--- a/.github/workflows/build-safari.yml
+++ b/.github/workflows/build-safari.yml
@@ -18,7 +18,7 @@ jobs:
           PROJ=$(find build -name '*.xcodeproj' | head -n 1)
           xcodebuild -project "$PROJ" -configuration Release CODE_SIGNING_ALLOWED=NO
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: safari-extension
           path: build


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to use `actions/upload-artifact@v4`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68574a1446b88327a7c352e9ef07ec39