### PR TITLE
Improve popup layout

### DIFF
--- a/extension/popup.css
+++ b/extension/popup.css
@@ -1,0 +1,22 @@
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Helvetica, Arial, sans-serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.header img {
+  width: 20px;
+  height: 20px;
+  margin-right: 0.5rem;
+}
+
+textarea#transcript {
+  font-size: 0.875rem;
+  line-height: 1.4;
+  resize: vertical;
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -7,10 +7,14 @@
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
         integrity="sha384-VmM3mcHkMvCGyxU8x5dR/MwZ0pniS3pSkeCZMt2rtI8BGG99HCaTKty+O3O5+y+N"
         crossorigin="anonymous">
+  <link rel="stylesheet" href="popup.css">
 </head>
-<body class="bg-light p-2">
+<body class="bg-light p-3">
   <div class="container-fluid">
-    <h1 class="h5 mb-2">Transcript</h1>
+    <div class="header">
+      <img src="icons/icon.png" alt="Udemy icon">
+      <h2 class="fs-6 mb-0">Transcript</h2>
+    </div>
     <textarea id="transcript" class="form-control" rows="10" readonly>
 Loading transcript...</textarea>
   </div>


### PR DESCRIPTION
## Summary
- make the popup header smaller and show plugin icon
- add custom CSS to improve typography and layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68575e9f96b08327ae838f29b4f364da