### PR TITLE
feat: record transcripts per chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # udemy-transcript-safari-plugin
 
-This repository contains a small Safari Web Extension that shows the
-transcript of the currently viewed Udemy video in a popup window.
-You can manually copy the transcript from the popup.
+This repository contains a small Safari Web Extension that records and
+displays transcripts for Udemy course chapters. While you watch a course with
+the transcript pane open, the extension stores each chapter's transcript in
+memory. Opening the extension popup shows a list of recorded chapters on the
+left and the selected chapter's transcript on the right for easy review and
+copying.
 
 ## Installing in Safari
 
@@ -12,10 +15,11 @@ You can manually copy the transcript from the popup.
    `extension` folder from this repository.
 
 3. In Safari Extension settings, allow the extension on `udemy.com` and set "When visiting other websites" to Deny.
-4. While watching a Udemy course video, click the extension icon. A popup will
-   appear containing the transcript text which you can select and copy. If the
-   popup reports that no transcript was found, make sure the transcript pane is
-   visible on the Udemy page.
+4. While watching a Udemy course video, open the transcript pane. The
+   extension automatically captures the transcript for each chapter you view.
+   Click the extension icon to open a popup showing the list of recorded
+   chapters and their transcripts. If the popup reports that no transcript was
+   found, make sure the transcript pane is visible on the Udemy page.
 
 The extension relies solely on the files in the `extension` directory and does
 not require any build steps. All styles are bundled locally so the popup works

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,13 +1,42 @@
 (function() {
+  const chapterTranscripts = {};
+  let currentChapter = '';
+
   function getTranscriptText() {
     const cueSpans = document.querySelectorAll('span[data-purpose="cue-text"]');
     const lines = Array.from(cueSpans).map(span => span.textContent.trim());
     return lines.join('\n');
   }
 
+  function getCurrentChapterName() {
+    const current = document.querySelector('li[class*="curriculum-item-link--is-current"]');
+    return current ? current.textContent.trim() : null;
+  }
+
+  function captureTranscript() {
+    const chapterName = getCurrentChapterName();
+    const transcript = getTranscriptText();
+    if (chapterName && transcript) {
+      currentChapter = chapterName;
+      if (chapterTranscripts[chapterName] !== transcript) {
+        chapterTranscripts[chapterName] = transcript;
+      }
+    }
+  }
+
+  // Poll for transcript updates only when transcript pane is present
+  setInterval(() => {
+    if (document.querySelector('span[data-purpose="cue-text"]')) {
+      captureTranscript();
+    }
+  }, 2000);
+
   browser.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     if (msg.action === 'getTranscript') {
       sendResponse({ transcript: getTranscriptText() });
+    }
+    if (msg.action === 'getTranscriptData') {
+      sendResponse({ currentChapter, transcripts: chapterTranscripts });
     }
   });
 })();

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -61,11 +61,37 @@ textarea#transcript {
   font-size: 0.875rem;
   line-height: 1.4;
   resize: vertical;
-  width: 100%;
+  flex: 1;
   min-height: 10rem;
+  margin-left: 0.5rem;
+  width: auto;
   border: 1px solid #b4b9bf;
   border-radius: 0.25rem;
   padding: 0.5rem;
   box-sizing: border-box;
   overflow-y: auto;
+}
+
+#content {
+  display: flex;
+}
+
+#chapters {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  width: 30%;
+  max-height: 260px;
+  overflow-y: auto;
+  border-right: 1px solid #b4b9bf;
+}
+
+#chapters li {
+  padding: 0.5rem;
+  cursor: pointer;
+}
+
+#chapters li.active {
+  background-color: #e9ecef;
+  font-weight: bold;
 }

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -11,8 +11,10 @@
       <img src="icons/icon.png" alt="Udemy icon">
       <h2 class="fs-6 mb-0">Transcript</h2>
     </div>
-    <textarea id="transcript" class="form-control" rows="10" readonly>
-Loading transcript...</textarea>
+    <div id="content">
+      <ul id="chapters"></ul>
+      <textarea id="transcript" class="form-control" rows="10" readonly>Loading transcript...</textarea>
+    </div>
   </div>
   <script src="popup.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- automatically poll Udemy transcript pane and store text per chapter
- redesign popup to list recorded chapters and show selected transcript
- document new behavior and popup layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a13fa8c81c8327aeae5f0db6b639b3