### PR TITLE
refactor: restrict extension permissions

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,10 +4,10 @@
   "version": "1.0",
   "manifest_version": 3,
   "permissions": [
-    "tabs"
+    "activeTab"
   ],
   "host_permissions": [
-    "*://*.udemy.com/*"
+    "https://www.udemy.com/*"
   ],
   "action": {
     "default_title": "Show Transcript",


### PR DESCRIPTION
## Summary
- use `activeTab` instead of `tabs` permission in manifest
- narrow host permissions to the main Udemy domain

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a14ec1d9948327b4b8e5f0d2752d7d