### PR TITLE
Add content security policy for extension pages

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -20,6 +20,9 @@
     "48": "icons/icon.png",
     "128": "icons/icon.png"
   },
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'none'"
+  },
   "content_scripts": [
     {
       "matches": ["*://*.udemy.com/*"],


### PR DESCRIPTION
## Summary
- define strict content security policy for extension pages

## Testing
- `npm test` (fails: Could not read package.json)
- `npx web-ext lint extension` (fails: 403 Forbidden to fetch package)

------
https://chatgpt.com/codex/tasks/task_e_68a155441b8083278cc615a0973608ab