### PR TITLE
Fix message validation so transcripts record again

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -14,7 +14,11 @@
 
   function getCurrentChapterName() {
     const current = document.querySelector('li[class*="curriculum-item-link--is-current"]');
-    return current ? current.textContent.trim() : null;
+    if (!current) {
+      return null;
+    }
+    const text = current.textContent.trim();
+    return text.replace(/^(Play|Stop)\s*/i, '').trim();
   }
 
   function captureTranscript() {

--- a/extension/content.js
+++ b/extension/content.js
@@ -43,7 +43,9 @@
   }, 2000);
 
   browser.runtime.onMessage.addListener((msg, sender, sendResponse) => {
-    const senderUrl = sender.url || (sender.tab && sender.tab.url) || '';
+    // Prefer the tab's URL when validating the sender so popup messages
+    // from the extension aren't rejected for having a moz-extension:// host.
+    const senderUrl = (sender.tab && sender.tab.url) || sender.url || '';
     const senderHost = senderUrl ? new URL(senderUrl).hostname : '';
     const isUdemyDomain = senderHost === 'udemy.com' || senderHost.endsWith('.udemy.com');
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -43,11 +43,9 @@
   }, 2000);
 
   browser.runtime.onMessage.addListener((msg, sender, sendResponse) => {
-    // Prefer the tab's URL when validating the sender so popup messages
-    // from the extension aren't rejected for having a moz-extension:// host.
-    const senderUrl = (sender.tab && sender.tab.url) || sender.url || '';
-    const senderHost = senderUrl ? new URL(senderUrl).hostname : '';
-    const isUdemyDomain = senderHost === 'udemy.com' || senderHost.endsWith('.udemy.com');
+    // Validate messages from this extension and ensure we're on a Udemy page.
+    const pageHost = window.location.hostname;
+    const isUdemyDomain = pageHost === 'udemy.com' || pageHost.endsWith('.udemy.com');
 
     if (sender.id !== browser.runtime.id || !isUdemyDomain) {
       return;
@@ -57,6 +55,7 @@
       sendResponse({ transcript: getTranscriptText() });
     }
     if (msg.action === 'getTranscriptData') {
+      captureTranscript();
       sendResponse({ currentChapter, transcripts: chapterTranscripts });
     }
   });

--- a/extension/content.js
+++ b/extension/content.js
@@ -43,7 +43,8 @@
   }, 2000);
 
   browser.runtime.onMessage.addListener((msg, sender, sendResponse) => {
-    const senderHost = sender.url ? new URL(sender.url).hostname : '';
+    const senderUrl = sender.url || (sender.tab && sender.tab.url) || '';
+    const senderHost = senderUrl ? new URL(senderUrl).hostname : '';
     const isUdemyDomain = senderHost === 'udemy.com' || senderHost.endsWith('.udemy.com');
 
     if (sender.id !== browser.runtime.id || !isUdemyDomain) {


### PR DESCRIPTION
## Summary
- allow content script to validate message sender via tab URL to ensure Udemy domain
- restore ability for popup to receive transcript data when transcript pane is open

## Testing
- `npm test` *(fails: enoent package.json)*

------
